### PR TITLE
Allow defaulting to `AreTomo` on PATH

### DIFF
--- a/lil_aretomo/aretomo.py
+++ b/lil_aretomo/aretomo.py
@@ -4,7 +4,8 @@ from typing import List, Optional
 from .utils import (
     prepare_imod_directory,
     align_tilt_series_aretomo,
-    find_binning_factor
+    find_binning_factor,
+    check_aretomo_availability,
 )
 
 
@@ -13,7 +14,7 @@ def run_aretomo_alignment(
         tilt_angles: List[float],
         pixel_size: float,
         output_directory: Path,
-        aretomo_executable: Path,
+        aretomo_executable: Optional[Path] = None,
         local_align: Optional[bool] = False,
         target_pixel_size: Optional[float] = 10,
         nominal_rotation_angle: Optional[float] = None,
@@ -43,6 +44,8 @@ def run_aretomo_alignment(
     This is useful is there is a lot of empty space at the top and bottom of your tomogram.
     See AreTomo manual for full explanation: this sets -AlignZ. Default is 800.
     """
+    if check_aretomo_availability() is False and aretomo_executable is None:
+        raise RuntimeError('AreTomo executable not found.')
 
     prepare_imod_directory(
         tilt_series_file=tilt_series_file,

--- a/lil_aretomo/aretomo.py
+++ b/lil_aretomo/aretomo.py
@@ -1,10 +1,5 @@
-from os import PathLike
 from pathlib import Path
-from typing import Dict, Any, Tuple, List, Optional
-from unittest.mock import _patch_dict
-import typer
-
-import subprocess
+from typing import List, Optional
 
 from .utils import (
     prepare_imod_directory,
@@ -18,13 +13,13 @@ def run_aretomo_alignment(
         tilt_angles: List[float],
         pixel_size: float,
         output_directory: Path,
-	    aretomo_executable: Path,
+        aretomo_executable: Path,
         local_align: Optional[bool] = False,
         target_pixel_size: Optional[float] = 10,
-	    nominal_rotation_angle: Optional[float] = None,
-        n_patches_xy: Optional[tuple[int,int]] = (5,4),
+        nominal_rotation_angle: Optional[float] = None,
+        n_patches_xy: Optional[tuple[int, int]] = (5, 4),
         correct_tilt_angle_offset: Optional[bool] = False,
-        thickness_for_alignment: Optional[float] = 800	
+        thickness_for_alignment: Optional[float] = 800
 ):
     """Run aretomo alignment on a single tilt-series
     
@@ -54,20 +49,20 @@ def run_aretomo_alignment(
         tilt_angles=tilt_angles,
         imod_directory=output_directory
     )
-    
-    binning=find_binning_factor(
+
+    binning = find_binning_factor(
         pixel_size=pixel_size,
         target_pixel_size=target_pixel_size
     )
-    
+
     align_tilt_series_aretomo(
         tilt_series_file=tilt_series_file,
         imod_directory=output_directory,
-	    binning=binning,
+        binning=binning,
         aretomo_executable=aretomo_executable,
-	    nominal_rotation_angle=nominal_rotation_angle,
+        nominal_rotation_angle=nominal_rotation_angle,
         local_align=local_align,
         n_patches_xy=n_patches_xy,
         correct_tilt_angle_offset=correct_tilt_angle_offset,
-        thickness_for_alignment=thickness_for_alignment	
+        thickness_for_alignment=thickness_for_alignment
     )

--- a/lil_aretomo/utils.py
+++ b/lil_aretomo/utils.py
@@ -1,94 +1,95 @@
 import os
 import subprocess
-import tempfile
 from pathlib import Path
-from typing import List, Dict
+from typing import List
 
 import numpy as np
 
+
 def prepare_imod_directory(
-        tilt_series_file: Path, 
-        tilt_angles: List[float], 
+        tilt_series_file: Path,
+        tilt_angles: List[float],
         imod_directory: Path
 ):
     ts_dir_name = tilt_series_file.stem
     imod_directory.mkdir(exist_ok=True, parents=True)
-    
-    #Rename file .mrc if .st    
+
+    # Rename file .mrc if .st
     if tilt_series_file.suffix == '.st':
-         tilt_series_file = tilt_series_file.with_suffix('.mrc')
+        tilt_series_file = tilt_series_file.with_suffix('.mrc')
 
     tilt_series_file_for_imod = imod_directory / tilt_series_file.name
     force_symlink(tilt_series_file.absolute(), tilt_series_file_for_imod)
 
     rawtlt_file = imod_directory / f'{ts_dir_name}.rawtlt'
     np.savetxt(rawtlt_file, tilt_angles, fmt='%.2f', delimiter='')
-    
-#####
+
 
 def align_tilt_series_aretomo(
-        tilt_series_file: Path, 
-        imod_directory: Path, 
+        tilt_series_file: Path,
+        imod_directory: Path,
         binning: float,
         aretomo_executable: Path,
-	    nominal_rotation_angle: bool or float,
+        nominal_rotation_angle: bool or float,
         local_align: bool,
-        n_patches_xy: tuple[int,int],
+        n_patches_xy: tuple[int, int],
         correct_tilt_angle_offset: bool,
-        thickness_for_alignment: float	
+        thickness_for_alignment: float
 ):
-        
-    #Rename file .mrc if .st    
+    # Rename file .mrc if .st
     if tilt_series_file.suffix == '.st':
-         tilt_series_file = tilt_series_file.with_suffix('.mrc')
-    
-    output_file_name = Path(f'{imod_directory}/{tilt_series_file.stem}_aln{tilt_series_file.suffix}')
-            
-	#Run AreTomo
+        tilt_series_file = tilt_series_file.with_suffix('.mrc')
+
+    output_file_name = Path(
+        f'{imod_directory}/{tilt_series_file.stem}_aln{tilt_series_file.suffix}')
+
+    # Run AreTomo
     aretomo_command = [
         f'{str(aretomo_executable)}',
         '-InMrc', f'{tilt_series_file}',
-        '-OutMrc', f'{output_file_name}', 
+        '-OutMrc', f'{output_file_name}',
         '-OutBin', f'{binning}',
         '-AngFile', f'{imod_directory}/{tilt_series_file.stem}.rawtlt',
-        '-AlignZ', f'{thickness_for_alignment}',	
+        '-AlignZ', f'{thickness_for_alignment}',
         '-VolZ', '0',
         '-OutXF', '1'
     ]
-    
+
     if not nominal_rotation_angle == None:
         aretomo_command.append('-TiltAxis')
         aretomo_command.append(f'{nominal_rotation_angle}')
-    
+
     if local_align:
         aretomo_command.append('-Patch')
         aretomo_command.append(f'{n_patches_xy[0]}')
         aretomo_command.append(f'{n_patches_xy[1]}')
-    
+
     if correct_tilt_angle_offset:
         aretomo_command.append('-TiltCor')
         aretomo_command.append('1')
-        
+
     subprocess.run(aretomo_command)
 
-    #Rename .tlt
+    # Rename .tlt
     tlt_file_name = Path(f'{imod_directory}/{tilt_series_file.stem}_aln.tlt')
     new_tlt_stem = tlt_file_name.stem[:-4]
     new_output_name_tlt = Path(f'{imod_directory}/{new_tlt_stem}').with_suffix('.tlt')
     tlt_file_name.rename(new_output_name_tlt)
-	
+
+
 #####
 
 def find_binning_factor(
-    pixel_size: float,
-    target_pixel_size: float
+        pixel_size: float,
+        target_pixel_size: float
 ) -> int:
-    #Find closest IMOD binning to reach target pixel size
+    # Find closest IMOD binning to reach target pixel size
     factors = 2 ** np.arange(7)
     binned_pixel_sizes = factors * pixel_size
     delta_pixel = np.abs(binned_pixel_sizes - target_pixel_size)
     binning = factors[np.argmin(delta_pixel)]
-    return binning	
+    return binning
+
 
 #####
 
@@ -97,7 +98,3 @@ def force_symlink(src: Path, link_name: Path):
     if link_name.exists():
         os.remove(link_name)
     os.symlink(src, link_name)
-
-
-
-

--- a/lil_aretomo/utils.py
+++ b/lil_aretomo/utils.py
@@ -1,8 +1,8 @@
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import List
-import shutil
 
 import numpy as np
 

--- a/lil_aretomo/utils.py
+++ b/lil_aretomo/utils.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 from pathlib import Path
 from typing import List
+import shutil
 
 import numpy as np
 
@@ -77,13 +78,11 @@ def align_tilt_series_aretomo(
     tlt_file_name.rename(new_output_name_tlt)
 
 
-#####
-
 def find_binning_factor(
         pixel_size: float,
         target_pixel_size: float
 ) -> int:
-    # Find closest IMOD binning to reach target pixel size
+    """Find closest power of two binning factor to reach target pixel size."""
     factors = 2 ** np.arange(7)
     binned_pixel_sizes = factors * pixel_size
     delta_pixel = np.abs(binned_pixel_sizes - target_pixel_size)
@@ -91,10 +90,13 @@ def find_binning_factor(
     return binning
 
 
-#####
-
 def force_symlink(src: Path, link_name: Path):
     """Force creation of a symbolic link, removing any existing file."""
     if link_name.exists():
         os.remove(link_name)
     os.symlink(src, link_name)
+
+
+def check_for_existing_aretomo_installation():
+    """Check for an installation of AreTomo on the PATH."""
+    return shutil.which('AreTomo') is not None

--- a/lil_aretomo/utils.py
+++ b/lil_aretomo/utils.py
@@ -97,6 +97,6 @@ def force_symlink(src: Path, link_name: Path):
     os.symlink(src, link_name)
 
 
-def check_for_existing_aretomo_installation():
+def check_aretomo_availability():
     """Check for an installation of AreTomo on the PATH."""
     return shutil.which('AreTomo') is not None


### PR DESCRIPTION
This PR makes the `aretomo_executable` parameter optional and adds a check for whether `AreTomo` is available on the PATH

edit: also ran a linter on the files, sorry for the larger diff