### PR TITLE
add automatic testing & deployment (no tests yet)

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,0 +1,69 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: ${{ matrix.platform }} py${{ matrix.python-version }}
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        python-version: ['3.8', '3.9', '3.10']
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools pytest
+      # this runs the tests using pytest
+      - name: Test with pytest
+        with:
+          run: python -m pytest tests
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
+      - name: Coverage
+        uses: codecov/codecov-action@v2
+
+  deploy:
+    # this will run when you have tagged a commit, starting with "v*"
+    # and requires that you have put your twine API key in your
+    # github secrets (see readme for details)
+    needs: [test]
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'tags')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -U setuptools setuptools_scm wheel twine build
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
+        run: |
+          git tag
+          python -m build .
+          twine upload dist/*

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,3 +1,6 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
 name: tests
 
 on:
@@ -8,7 +11,7 @@ on:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
   pull_request:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:
@@ -31,16 +34,17 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools pytest
-      # this runs the tests using pytest
+          pip install setuptools pytest
+          pip install -e .
+
+      # this runs the platform-specific tests
       - name: Test with pytest
-        with:
-          run: python -m pytest tests
+        run: pytest tests
         env:
           PLATFORM: ${{ matrix.platform }}
 
       - name: Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v1
 
   deploy:
     # this will run when you have tagged a commit, starting with "v*"
@@ -58,12 +62,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -U setuptools setuptools_scm wheel twine build
+          pip install -U setuptools setuptools_scm wheel twine
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
         run: |
           git tag
-          python -m build .
+          python setup.py sdist bdist_wheel
           twine upload dist/*


### PR DESCRIPTION
This PR adds a github action for automatically running tests and deploying if appropriate

- tests are run on all pull requests
- deployment is run for commits to main which contain tags with `v*` in them

The deployment process then becomes:

```sh
# make sure local is in sync with remote (including any newly merged pull requests)
git fetch --all 
git checkout main
git pull origin main

# tag the commit, push to remote
git tag -a v0.0.1rc9 -m "v0.0.1rc9"
git push --follow-tags
```

This will kick off the workflow, running tests and if the tests pass, deploying to PyPI

For PyPI to know you want this deployment to be allowed you will need to add your twine API key as a repository secret:

Generate an [API token](https://pypi.org/help/#apitoken) at PyPi: In your [account settings](https://pypi.org/manage/account/) go to the API tokens section and select "Add API token". Make sure to copy it somewhere safe!

[Create a new encrypted secret](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets)" in your github repository with the name "TWINE_API_KEY", and paste in your API token.
